### PR TITLE
fix: old file templates and small TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **LinkedIn:** [Maxime Beauchamp](https://www.linkedin.com/in/maxbeauchamp/)  
 **Date Created:** 2024-11-06
 
-Modifications:
+Modifications:  
 **Author:** UnBonWhisky / Flavien Fouqueray  
 **LinkedIn:** [Flavien Fouqueray](https://www.linkedin.com/in/ffouqueray/)  
 **Date Last Edition:** 2025-03-06

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 **LinkedIn:** [Maxime Beauchamp](https://www.linkedin.com/in/maxbeauchamp/)  
 **Date Created:** 2024-11-06
 
+Modifications:
+**Author:** UnBonWhisky / Flavien Fouqueray  
+**LinkedIn:** [Flavien Fouqueray](https://www.linkedin.com/in/ffouqueray/)  
+**Date Last Edition:** 2025-03-06
+
 ## Description
 
 `CIS Benchmark Converter` is a Python script designed to extract recommendations from CIS Benchmark PDF documents and export them into CSV or Excel format. The output provides a structured, easy-to-read table format that simplifies compliance checks and reviews.

--- a/cis_benchmark_converter.py
+++ b/cis_benchmark_converter.py
@@ -60,7 +60,7 @@ init(autoreset=True)
 recommendation_pattern = re.compile(r'^\s*(\d+(?:\.\d+)+)\s+(.+)')  # Matches numbers like 1.1.1, 2.2.2.2, etc.
 remove_pattern = re.compile(r'Page\s\d{1,4}|•')
 remove_pattern2 = re.compile(r'\d{1,4}\s*\|\s*P\s*a\s*ge')
-title_pattern = re.compile(r'^([1-9]+\.\d+(?:\.\d+)*)\s*(\(L\d+\))?\s*(.*)')
+title_pattern = re.compile(r'^([1-9]\d{0,1}\.\d+(?:\.\d+)*)\s*(\(L\d+\))?\s*(.*)')
 
 # Pattern to remove page numbers (e.g., "Page 123")
 page_number_pattern = re.compile(r'\bPage\s+\d+\b', re.IGNORECASE)

--- a/cis_benchmark_converter.py
+++ b/cis_benchmark_converter.py
@@ -225,7 +225,7 @@ def read_pdf(input_file):
                     log_debug(f"Recommendations section detected. Starting extraction... (This may take a while)")
             
             if extraction_started:
-                if "Appendix: Summary Table" in page_text or "Checklist" in page_text:
+                if "Appendix: Summary Table" in page_text or ("Checklist" in page_text and not any(title_pattern.match(line) for line in page_text.splitlines() if "Checklist" in line)):
                     log_debug("End of Recommendations section reached.")
                     break
                 text.append(page_text)


### PR DESCRIPTION
Hello, the PR fix the following issues :
- Page numbers were not cleared on old files (eg : Apple OSX 10.8 benchmark)
- Recommendations section were not found because the scrapping started at page 10 and on certain files it started at page 8 or less (eg : Apple OSX 10.8 benchmark)
- IP 0.0.0.0/0 were recognized itself as a title but a recommendation never start by a 0 (eg : Microsoft Azure Foundations Benchmark)
- Files may have 1000+ pages (Red Hat Entreprise Linux 8 STIG benchmark)

After my 2 commits, I pushed another fix :
- When a title started by 10 or more, it was not recognized correctly due to regex modification that only allowed 1 digit. (my fault tbh)
  - Now it accepts up to 2 digits, allowing to go up to 99.X.Y.Z. And avoiding error about 255.255.255.255 in titles